### PR TITLE
[DS] Removes FET dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "chai": "^3.5.0",
     "css-loader": "^0.28.4",
     "enzyme": "^2.8.2",
-    "frontend-toolkit": "^9.1.0",
     "jsdom": "^9.8.0",
     "json-loader": "^0.5.4",
     "jsonfile": "^3.0.0",


### PR DESCRIPTION
I think by removing the FET dependency, we enable external candidates to build this.  `npm install` should now be possible since we don't need to reach artifactory.